### PR TITLE
Hh/token handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "redux-persist": "^6.0.0",
     "redux-saga": "^1.3.0",
     "web-vitals": "^2.1.4",
-    "yup": "^1.4.0"
+    "yup": "^1.4.0",
+    "jwt-decode": "^4.0.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rich-crm",
-  "version": "0.0.3.dev",
+  "version": "0.0.5.dev",
   "private": true,
   "dependencies": {
     "@azure/msal-browser": "^3.21.0",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "rich-crm",
   "version": "0.0.3.dev",
   "private": true,
+  "type": "module",
   "dependencies": {
     "@azure/msal-browser": "^3.21.0",
     "@azure/msal-react": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -41,8 +41,7 @@
     "redux-persist": "^6.0.0",
     "redux-saga": "^1.3.0",
     "web-vitals": "^2.1.4",
-    "yup": "^1.4.0",
-    "jwt-decode": "^4.0.0"
+    "yup": "^1.4.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "rich-crm",
   "version": "0.0.3.dev",
   "private": true,
-  "type": "module",
   "dependencies": {
     "@azure/msal-browser": "^3.21.0",
     "@azure/msal-react": "^2.1.0",
@@ -42,7 +41,8 @@
     "redux-persist": "^6.0.0",
     "redux-saga": "^1.3.0",
     "web-vitals": "^2.1.4",
-    "yup": "^1.4.0"
+    "yup": "^1.4.0",
+    "jwt-decode": "^4.0.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/axios/interceptor.js
+++ b/src/axios/interceptor.js
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { jwtDecode } from "jwt-decode";
+import { jwtDecode } from 'jwt-decode'
 
 const axiosInstance = axios.create({
   baseURL:process.env.REACT_APP_BASE_URL,
@@ -8,7 +8,9 @@ const axiosInstance = axios.create({
   },
 });
 
-const isTokenExpired = (token) => { try { return jwtDecode(token).exp * 1000 < Date.now(); } catch { return true; } };
+const isTokenExpired = (token) => { 
+  try { return jwtDecode(token).exp * 1000 < Date.now(); } catch { return true; } 
+};
 
 axiosInstance.interceptors.request.use(
   async (request) => {

--- a/src/axios/interceptor.js
+++ b/src/axios/interceptor.js
@@ -1,5 +1,4 @@
 import axios from "axios";
-import { jwtDecode } from 'jwt-decode'
 
 const axiosInstance = axios.create({
   baseURL:process.env.REACT_APP_BASE_URL,
@@ -8,38 +7,26 @@ const axiosInstance = axios.create({
   },
 });
 
-const isTokenExpired = (token) => { 
-  try { return jwtDecode(token).exp * 1000 < Date.now(); } catch { return true; } 
+// Flag to indicate refreshing is in progress
+let isRefreshing = false;
+// Queue for callbacks
+let refreshQue = [];
+
+// Use to notify all queued once new authtoken is obtained
+const refreshingProcc = (newAccessToken) => {
+  refreshQue.forEach((callback) => callback(newAccessToken));
+  refreshQue = [];
 };
 
+// Add request to the queue, and called once token is refreshed
+const addNewReq = (callback) => { refreshQue.push(callback); };
+
 axiosInstance.interceptors.request.use(
-  async (request) => {
+  (request) => {
     const authToken = localStorage.getItem("authToken");
 
-    if (!authToken) return request;
-    
-    if (!isTokenExpired(authToken)) {
+    if(authToken) {
       request.headers["Authorization"] = `Bearer ${authToken}`;
-    }
-    else {
-      try {
-        const refreshToken = localStorage.getItem("refreshToken");
-        const refreshResponse = await axios.post("/auth/refresh", { refreshToken }, { withCredentials: true });
-        const { access: newAccessToken} = refreshResponse.data[0].token.access;
-
-        if (newAccessToken) {
-          localStorage.setItem("authToken", newAccessToken);
-          request.headers["Authorization"] = `Bearer ${newAccessToken}`;
-        }
-        else {
-          localStorage.clear();
-          window.location.href = "/";
-        }
-      } catch (error) {
-        localStorage.clear();
-        window.location.href = "/";
-        return Promise.reject(error);
-      }
     }
 
     return request;
@@ -52,23 +39,71 @@ axiosInstance.interceptors.request.use(
 axiosInstance.interceptors.response.use(
   (response) => {
     const { access: accessToken, refresh: refreshToken } = response?.data?.data?.[0]?.token ?? {};
+
     if (accessToken) {
       localStorage.setItem("authToken", accessToken);
     }
     if (refreshToken) {
       localStorage.setItem("refreshToken", refreshToken);
     }
-    if (response.status === 208) {
-      localStorage.clear();
-      window.location.href = "/";
-    }
+
     return response;
   },
-  (error) => {
-    if (error.response && error.response.status === 404) {
+  async (error) => {
+    const originalRequest = error.config;
+
+    if (error.response && error.response.status === 401 && !originalRequest._retry) { // handle 401 erros: token may be expired 
+      originalRequest._retry = true;
+
+      const refreshToken = localStorage.getItem("refreshToken");
+
+      if (!refreshToken) {
+        localStorage.clear();
+        window.location.href = "/";
+        return Promise.reject(error);
+      }
+
+      // If token is refreshing, this request is push into queue
+      if(isRefreshing) { 
+        return new Promise((resolve) => {
+          addNewReq((newAccessToken) => { originalRequest.headers["Authorization"] = `Bearer ${newAccessToken}`;
+          resolve(axiosInstance(originalRequest)); });
+        });
+      }
+
+      // Refresh process begin if refreshing is not in progress
+      isRefreshing = true;
+
+      try {
+        const refreshRespone = await axios.post(`${process.env.REACT_APP_BASE_URL}/auth/refresh`, { refreshToken }, { withCredentials: true});
+        const { access: newAccessToken } = refreshRespone.data?.[0]?.token?.access || {};
+
+        if(newAccessToken) {
+          localStorage.setItem("authToken", newAccessToken);
+          isRefreshing = false;
+          refreshingProcc(newAccessToken);
+
+          originalRequest.headers["Authorization"] = `Bearer ${newAccessToken}`; // Retry the previous request with this new auth token
+
+          return axiosInstance(originalRequest);
+        } else {
+          // clear the local and re-ithenticate use if failed to retrieve a new token
+          isRefreshing = false;
+          localStorage.clear();
+          window.location.href = "/";
+          return Promise.reject(error);
+        }
+      } catch (refreshError) {
+        // If we failed to retrive a new access token, user must re-login
+        console.error("Failed to obatin a new authToken:", refreshError);
+        isRefreshing = false;
+        localStorage.clear();
+        window.location.href = "/";
+        return Promise.reject(refreshError);
+      }
+
+    } else if (error.response && error.response.status === 404) {
       console.error("Resource not found");
-    } else if (error.response && error.response.status === 401) {
-      console.error("Unauthorized - token might be expired")
     } else if (error.response && error.response.status === 500) {
       console.error("Server error - please try again later");
     }

--- a/src/axios/interceptor.js
+++ b/src/axios/interceptor.js
@@ -1,4 +1,5 @@
 import axios from "axios";
+import { jwtDecode } from "jwt-decode";
 
 const axiosInstance = axios.create({
   baseURL:process.env.REACT_APP_BASE_URL,
@@ -7,11 +8,36 @@ const axiosInstance = axios.create({
   },
 });
 
+const isTokenExpired = (token) => { try { return jwtDecode(token).exp * 1000 < Date.now(); } catch { return true; } };
+
 axiosInstance.interceptors.request.use(
-  (request) => {
+  async (request) => {
     const authToken = localStorage.getItem("authToken");
-    if (authToken) {
+
+    if (!authToken) return request;
+    
+    if (!isTokenExpired(authToken)) {
       request.headers["Authorization"] = `Bearer ${authToken}`;
+    }
+    else {
+      try {
+        const refreshToken = localStorage.getItem("refreshToken");
+        const refreshResponse = await axios.post("/auth/refresh", { refreshToken }, { withCredentials: true });
+        const { access: newAccessToken} = refreshResponse.data[0].token.access;
+
+        if (newAccessToken) {
+          localStorage.setItem("authToken", newAccessToken);
+          request.headers["Authorization"] = `Bearer ${newAccessToken}`;
+        }
+        else {
+          localStorage.clear();
+          window.location.href = "/";
+        }
+      } catch (error) {
+        localStorage.clear();
+        window.location.href = "/";
+        return Promise.reject(error);
+      }
     }
 
     return request;
@@ -23,8 +49,15 @@ axiosInstance.interceptors.request.use(
 
 axiosInstance.interceptors.response.use(
   (response) => {
+    const { access: accessToken, refresh: refreshToken } = response?.data?.data?.[0]?.token ?? {};
+    if (accessToken) {
+      localStorage.setItem("authToken", accessToken);
+    }
+    if (refreshToken) {
+      localStorage.setItem("refreshToken", refreshToken);
+    }
     if (response.status === 208) {
-      localStorage.removeItem("authToken");
+      localStorage.clear();
       window.location.href = "/";
     }
     return response;
@@ -32,6 +65,8 @@ axiosInstance.interceptors.response.use(
   (error) => {
     if (error.response && error.response.status === 404) {
       console.error("Resource not found");
+    } else if (error.response && error.response.status === 401) {
+      console.error("Unauthorized - token might be expired")
     } else if (error.response && error.response.status === 500) {
       console.error("Server error - please try again later");
     }


### PR DESCRIPTION
1. Token Extraction and Storage:
- Extract the accessToken and refreshToken from response coming from the back end, and store both tokens into local storage. 

2. Verify Token:
- In the interceptor request use, I add the following functions: checking expiration of the access token before sending it, once token has "Expired", use the refresh token in the local storage to obtain the new access token by calling "auth/refresh", and includes a Bearer token in the request header when making API calls.

3. To import jwtDecode from "jwt-decode", set "type": "module" in the package.json.